### PR TITLE
32 movement name exists

### DIFF
--- a/gridt/controllers/movements.py
+++ b/gridt/controllers/movements.py
@@ -51,8 +51,8 @@ def get_movement(movement_identifier, user_id):
     """Get a movement."""
     with session_scope() as session:
         try:
-            movement_identifier = int(movement_identifier)
-            movement = load_movement(movement_identifier, session)
+            movement_id = int(movement_identifier)
+            movement = load_movement(movement_id, session)
         except ValueError:
             movement = (
                 session.query(Movement)
@@ -62,6 +62,24 @@ def get_movement(movement_identifier, user_id):
 
         user = load_user(user_id, session)
         return extend_movement_json(movement, user, session)
+
+
+def movement_name_exists(movement_name: str) -> bool:
+    """
+    Is the provided movement name currently in use.
+
+    Args:
+        movement_name (str): The movement name as a string.
+
+    Returns:
+        bool: True if a movement already has this name, and False otherwise.
+    """
+    with session_scope() as session:
+        movement = session.query(Movement).filter_by(
+            name=movement_name
+        ).one_or_none()
+
+        return (movement is not None)
 
 
 def movement_exists(movement_id):

--- a/gridt/controllers/movements.py
+++ b/gridt/controllers/movements.py
@@ -47,20 +47,20 @@ def get_all_movements(user_id):
         ]
 
 
-def get_movement(movement_identifier, user_id):
-    """Get a movement."""
-    with session_scope() as session:
-        try:
-            movement_id = int(movement_identifier)
-            movement = load_movement(movement_id, session)
-        except ValueError:
-            movement = (
-                session.query(Movement)
-                .filter_by(name=movement_identifier)
-                .one()
-            )
+def get_movement(movement_id: int, user_id: int) -> dict:
+    """
+    Get a movement as user.
 
+    Args:
+        movement_id (int): The id of the movement to get.
+        user_id (int): The id of the user to get movement as.
+
+    Returns:
+        dict: the JSON representation of the movement.
+    """
+    with session_scope() as session:
         user = load_user(user_id, session)
+        movement = load_movement(movement_id, session)
         return extend_movement_json(movement, user, session)
 
 

--- a/gridt/tests/controllers/test_movements.py
+++ b/gridt/tests/controllers/test_movements.py
@@ -6,7 +6,11 @@ from gridt.tests.basetest import BaseTest
 from gridt.models import Movement, Subscription, UserToUserLink
 
 from gridt.controllers.leader import send_signal
-from gridt.controllers.movements import get_movement, create_movement
+from gridt.controllers.movements import (
+    get_movement,
+    create_movement,
+    movement_name_exists
+)
 
 from datetime import datetime
 
@@ -93,6 +97,15 @@ class MovementControllerUnitTests(BaseTest):
             },
         }
         self.assertDictEqual(get_movement(movement.id, user_2.id), expected)
+
+    def test_movement_name_exists(self):
+        movement = self.create_movement()
+        name = movement.name
+        not_name = "Not " + name
+        self.session.commit()
+
+        self.assertTrue(movement_name_exists(movement_name=name))
+        self.assertFalse(movement_name_exists(movement_name=not_name))
 
 
 class MovementControllerIntergrationTests(BaseTest):

--- a/gridt/tests/controllers/test_movements.py
+++ b/gridt/tests/controllers/test_movements.py
@@ -99,6 +99,7 @@ class MovementControllerUnitTests(BaseTest):
         self.assertDictEqual(get_movement(movement.id, user_2.id), expected)
 
     def test_movement_name_exists(self):
+        """Unittest for movement_name_exists."""
         movement = self.create_movement()
         name = movement.name
         not_name = "Not " + name


### PR DESCRIPTION
This is about issue #32.
The problem this addresses is that in the server repository, the `MovementSchema` incorrectly uses the `get_movement` function to check if a movement name is available. This pull request fixes this issue by introducing `movement_name_exists` the schema can use instead.
