### PR TITLE
CI for testpypi gridt-library package

### DIFF
--- a/.github/workflows/publish-to-test-pypi.yml
+++ b/.github/workflows/publish-to-test-pypi.yml
@@ -1,0 +1,46 @@
+name: Publish Python 🐍 distributions 📦 to TestPyPI
+
+on:
+  push:
+    branches:
+      - development
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+
+      - name: Install pypa/build
+        run: >-
+          python -m
+          pip install
+          build
+          --user
+
+      - name: Print Version
+        run: echo "Version is ${{ vars.VERSION }}"
+
+      - name: Build a binary wheel and a source tarball
+        run: >-
+          python -m
+          build
+          --sdist
+          --wheel
+          --outdir dist/
+        env:
+          VERSION: ${{ vars.VERSION }}
+
+      - name: Publish distribution 📦 to Test PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+          repository-url: https://test.pypi.org/legacy/
+          skip-existing: true

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,9 @@
 """The setup script."""
 
 from setuptools import setup, find_packages
+import os
+
+version = os.getenv('VERSION', '0.0.1')
 
 with open("README.md", "r") as fh:
     long_description = fh.read()
@@ -37,10 +40,10 @@ setup(
     install_requires=requirements,
     license="MIT license",
     include_package_data=True,
-    keywords='gridtlib',
-    name='gridtlib',
+    keywords='gridt-library',
+    name='gridt-library',
     packages=find_packages(include=['gridt', 'gridt.*']),
     url='https://github.com/GridtNetwork/gridtlib',
-    version='0.0.1',
+    version=version,
     zip_safe=False,
 )


### PR DESCRIPTION
This pull request resolves half of #31, namely, the automatic integration of TestPyPi on pushes to development. It uses the project variable VERSION to set the version of the package. Few things to note: Firstly, I had to create a [new TestPyPi package](https://test.pypi.org/project/gridt-library/0.0.1/). Secondly, the version project variable should be updated every time new code is pushed to development. Thirdly, imports work as follows:
```
from gridt.controllers.movements import *
```
So we will have to change this in the server as well.

In the future, we can automate the changing of version numbers as part of the CI process. This requires labels for releases.